### PR TITLE
Refactor: Restructure navigation to two levels

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,5 +1,5 @@
 ---
-title: The First Dirty Dozen
+title: Introduction
 layout: home
 nav_order: 1
 ---
@@ -101,6 +101,6 @@ The book is organized around these three themes, and will add some additional co
 Management can be divided into three equally important responsibilities: People, Projects, and Resources (money, tools, and time). We will go over each of these in the following sections.
 
 ## Sections
-*   [People Management](./people/) (Content to be added)
-*   [Product Management](./product/) (Content to be added)
-*   [Resource Management](./resources/) (Content to be added)
+*   [People Management](./management/people.html) (Content to be added)
+*   [Product Management](./management/product.html) (Content to be added)
+*   [Resource Management](./management/resources.html) (Content to be added)

--- a/management/index.md
+++ b/management/index.md
@@ -1,0 +1,7 @@
+---
+title: Management
+layout: default
+nav_order: 2 # This will come after 'Introduction'
+has_children: true
+---
+# Management

--- a/management/people.md
+++ b/management/people.md
@@ -1,7 +1,8 @@
 ---
-title: People Management
-layout: home
-nav_order: 2
+title: People
+layout: default
+nav_order: 1
+parent: Management
 ---
 
 {: .no_toc }

--- a/management/product.md
+++ b/management/product.md
@@ -1,7 +1,8 @@
 ---
-title: Product Management
-layout: home
-nav_order: 3
+title: Product
+layout: default
+nav_order: 2
+parent: Management
 ---
 
 {: .no_toc }

--- a/management/resources.md
+++ b/management/resources.md
@@ -1,7 +1,8 @@
 ---
-title: Resource Management
-layout: home
-nav_order: 4
+title: Resources
+layout: default
+nav_order: 3
+parent: Management
 ---
 {: .no_toc }
 # Resources and Budgets

--- a/operational/devops.md
+++ b/operational/devops.md
@@ -1,9 +1,9 @@
 ---
 title: CI/CD and DevOps
-layout: home
-nav_order: 4.3
+layout: default
+nav_order: 2
+parent: Operational
 ---
-
 {: .no_toc }
 # CI/CD and DevOps Practices
 

--- a/operational/index.md
+++ b/operational/index.md
@@ -1,0 +1,7 @@
+---
+title: Operational
+layout: default
+nav_order: 3 # This will come after 'Management'
+has_children: true
+---
+# Operational

--- a/operational/security.md
+++ b/operational/security.md
@@ -1,9 +1,9 @@
 ---
 title: Security and Compliance
-layout: home
-nav_order: 4.1
+layout: default
+nav_order: 1
+parent: Operational
 ---
-
 {: .no_toc }
 # Security Compliance and Regulations
 
@@ -124,4 +124,4 @@ Monitor continuously and implement intelligent alerting.
 * **Compliance Automation**: Secureframe, Tugboat Logic, Ostendio
 * **Security Monitoring**: Datadog, Splunk, Elastic Security
 * **Vendor Management**: OneTrust VRM, Whistic, SecurityScorecard
-* **Training and Awareness**: KnowBe4, Proofpoint Security Awareness, SANS 
+* **Training and Awareness**: KnowBe4, Proofpoint Security Awareness, SANS


### PR DESCRIPTION
This commit reorganizes the site navigation from a single level to a two-level hierarchy as follows:

- Introduction
- Management
  - People
  - Product
  - Resources
- Operational
  - Security
  - DevOps

Key changes include:
- Created `management` and `operational` directories.
- Moved existing top-level pages (`people`, `product`, `resources`) under `management`.
- Created new pages for `Security` and `DevOps` under `operational`, sourcing content from existing files in the `resources` directory.
- Updated front matter (title, nav_order, parent, has_children, layout) across all affected files to implement the new structure using Just the Docs theme conventions.
- Updated internal links on the main `index.md` page.